### PR TITLE
update formation to 1.3.1 and add `motion-require' which is required by formation 1.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'rake'
 gem 'motion-cocoapods'
 gem 'sugarcube'
 gem "bubble-wrap"
+gem 'motion-require'
 gem 'formotion'
 # gem 'rm-digest'
 gem 'rm-wsse'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     cocoapods-downloader (0.1.1)
     colored (1.2)
     escape (0.0.4)
-    formotion (1.2)
+    formotion (1.3.1)
       bubble-wrap (>= 1.1.4)
     i18n (0.6.1)
     json (1.8.0)
@@ -32,6 +32,7 @@ GEM
     motion-pixate (1.2)
       sass
     motion-pixate-observer (0.5)
+    motion-require (0.0.6)
     multi_json (1.7.7)
     nap (0.5.1)
     open4 (1.3.0)
@@ -56,6 +57,7 @@ DEPENDENCIES
   motion-cocoapods
   motion-pixate
   motion-pixate-observer
+  motion-require
   rake
   rm-wsse
   sugarcube


### PR DESCRIPTION
古い formation を使っているとテキストフィールドを長押しした際に、ペーストするためのメニューが表示されないようです。
1 password アプリで生成したランダムな文字を、1文字ずつ正しく打ち込むのが大変なのでペーストできるようになると嬉しいです。

formation 1.3.1 では、期待した通りメニューが表示されるようです。
![Paste](http://cdn-ak.f.st-hatena.com/images/fotolife/W/Watson/20130713/20130713024037.png?1373650845)
