### PR TITLE
アプリ利用中のプッシュ通知を表示する/しない設定

### DIFF
--- a/app/controller/notification_config_view_controller.rb
+++ b/app/controller/notification_config_view_controller.rb
@@ -9,19 +9,27 @@ class NotificationConfigViewController < Formotion::FormController
             {
               title: "プッシュ通知",
               rows: [
-                title: "Webhookキー",
-                key: "webhook_key",
-                type: :ascii,
-                placeholder: '必須',
-                auto_correction: :no,
-                auto_capitalization: :none,
-                value: user.webhook_key
+                {
+                  title: "Webhookキー",
+                  key: "webhook_key",
+                  type: :ascii,
+                  placeholder: '必須',
+                  auto_correction: :no,
+                  auto_capitalization: :none,
+                  value: user.webhook_key
+                },
+                {
+                  title: "アプリ利用中も通知",
+                  key: 'notify_when_state_active',
+                  type: 'switch',
+                  value: user.wants_notification_when_state_active?
+                }
               ],
               footer:
-              "1. 任意の文字列を指定してください\n" +
+              "1. Webhookキーに任意の文字列を指定してください\n" +
               "(平文でやり取りされるのでパスワード文字列は利用しないでください)\n\n" +
-              "2. はてなブックマーク本体の Webhook 設定の「イベント通知URL」に http://push.hbfav.com/#{user.hatena_id} を、「キー」にここで入力したのと同じ文字列をそれぞれ設定してください\n\n" +
-              "3. 通知して欲しいイベント種類の設定などは、はてなブックマーク本体で行ってください"
+              "2. はてなブックマーク本体の Webhook 設定で「イベント通知URL」に http://push.hbfav.com/#{user.hatena_id} を、「キー」にここで入力したのと同じ文字列をそれぞれ設定してください\n\n" +
+              "3. 受け取る通知種類の設定は、はてなブックマーク本体で行ってください"
             }
           ]
         }
@@ -33,7 +41,6 @@ class NotificationConfigViewController < Formotion::FormController
   def viewDidLoad
     super
     self.navigationItem.title = "設定"
-    # self.view.backgroundColor = UIColor.groupTableViewBackgroundColor
   end
 
   def viewWillAppear(animated)
@@ -63,6 +70,7 @@ class NotificationConfigViewController < Formotion::FormController
     else
       user = ApplicationUser.sharedUser
       user.webhook_key = data["webhook_key"]
+      user.disable_notification_when_state_active = !data['notify_when_state_active']
       user.save
 
       UIApplication.sharedApplication.registerForRemoteNotificationTypes(

--- a/app/model/application_user.rb
+++ b/app/model/application_user.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 class ApplicationUser
-  attr_accessor :hatena_id, :use_timeline, :send_bugreport, :webhook_key
+  attr_accessor :hatena_id, :use_timeline, :send_bugreport, :webhook_key, :disable_notification_when_state_active
 
   def self.sharedUser
     Dispatch.once { @instance ||= new }
@@ -12,6 +12,7 @@ class ApplicationUser
     App::Persistence['use_timeline'] = @use_timeline
     App::Persistence['send_bugreport'] = @send_bugreport
     App::Persistence['webhook_key'] = @webhook_key
+    App::Persistence['disable_notification_when_state_active'] = @disable_notification_when_state_active
     self
   end
 
@@ -20,6 +21,7 @@ class ApplicationUser
     self.use_timeline = App::Persistence['use_timeline']
     self.send_bugreport = App::Persistence['send_bugreport']
     self.webhook_key = App::Persistence['webhook_key']
+    self.disable_notification_when_state_active = App::Persistence['disable_notification_when_state_active']
     self
   end
 
@@ -41,6 +43,10 @@ class ApplicationUser
 
   def wants_remote_notification?
     self.webhook_key ? true : false
+  end
+
+  def wants_notification_when_state_active?
+    self.disable_notification_when_state_active ? false : true
   end
 
   def enable_remote_notification!(token)

--- a/app/remote_notification_delegate.rb
+++ b/app/remote_notification_delegate.rb
@@ -17,7 +17,6 @@ module HBFav2
     def application(application, didReceiveRemoteNotification:userInfo)
       case application.applicationState
       when UIApplicationStateActive then
-        @logo ||= UIImage.imageNamed("default_app_logo.png")
         if userInfo.present? and userInfo['aps']
           ## LocalNotification で Notification Center に転送
           notification = UILocalNotification.new
@@ -27,15 +26,18 @@ module HBFav2
             application.presentLocalNotificationNow(notification)
           end
 
-          banner = MPNotificationView.notifyWithText(
-            "HBFav",
-            detail:userInfo['aps']['alert'],
-            image:@logo,
-            duration:3.0,
-            andTouchBlock:lambda { |notificationView| self.handleNotificationPayload(userInfo) }
-          )
-          banner.detailTextLabel.font = UIFont.systemFontOfSize(13)
-          banner.detailTextLabel.textColor = "#333333".uicolor
+          if ApplicationUser.sharedUser.wants_notification_when_state_active?
+            @logo ||= UIImage.imageNamed("default_app_logo.png")
+            banner = MPNotificationView.notifyWithText(
+              "HBFav",
+              detail:userInfo['aps']['alert'],
+              image:@logo,
+              duration:3.0,
+              andTouchBlock:lambda { |notificationView| self.handleNotificationPayload(userInfo) }
+            )
+            banner.detailTextLabel.font = UIFont.systemFontOfSize(13)
+            banner.detailTextLabel.textColor = "#333333".uicolor
+          end
         end
       when UIApplicationStateInactive then
         PFAnalytics.trackAppOpenedWithRemoteNotificationPayload(userInfo)


### PR DESCRIPTION
MPNotificationView による通知が若干処理落ちをするし、アプリがフォアグラウンドにあるときの通知は切っておきたいユーザーもいそうなので設定のON/OFFを追加

![20130904_200836](https://f.cloud.github.com/assets/8991/1079810/6ab2f730-1552-11e3-81db-9b62b5609a60.png)
