### PR TITLE
support open web page from mobile safari

### DIFF
--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -116,9 +116,20 @@ class AppDelegate
   end
 
   def application(application, openURL:url, sourceApplication:sourceApplication, annotation:annotation)
-    if PocketAPI.sharedAPI.handleOpenURL(url)
-      return true
+
+    case sourceApplication
+    when 'com.apple.mobilesafari'
+      target_url = url.absoluteString.match(/^hbfav2\:(.*)/)[1]
+
+      unless target_url.empty?
+        self.presentWebViewControllerWithURL(target_url)
+      end
+    else
+      if PocketAPI.sharedAPI.handleOpenURL(url)
+        return true
+      end
     end
+
     return true
   end
 


### PR DESCRIPTION
mobile safariからのブックマークレットを使った「webページを開く」を実装してみました。

PocketAPI との処理の分岐は sourceApplication を参照して分岐するようにしています。
課題としては、sourceApplication で判断しているため、ブラウザ毎に対応する必要があるので、もう少しベストプラクティスな方法がないか検討してみたいところですね。
##### 動作確認の方法
1. HBFav2 を起動する
2. mobile safari に切り替える
3. mobile safari のブックマークから適当なページを開く
4. 下記のブックマークレットを mobile safari のアドレスバーに貼り付けて実行する
   `javascript:window.location='hbfav2:'+window.location`

4 のブックマークレットの貼り付けがうまくいかない場合は、一度アドレスバーのURLを削除した状態でペーストすると良いと思います。
