### PR TITLE
fix conflict sourceApplication from PocketAPI

### DIFF
--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -117,13 +117,11 @@ class AppDelegate
 
   def application(application, openURL:url, sourceApplication:sourceApplication, annotation:annotation)
 
-    case sourceApplication
-    when 'com.apple.mobilesafari'
-      target_url = url.absoluteString.match(/^hbfav2\:(.*)/)[1]
+    case
+    when matches = url.absoluteString.match(/^hbfav2:\/\/page\/open\/(.*)/)
+      target_url = matches[1]
 
-      unless target_url.empty?
-        self.presentWebViewControllerWithURL(target_url)
-      end
+      self.presentWebViewControllerWithURL(target_url)
     else
       if PocketAPI.sharedAPI.handleOpenURL(url)
         return true


### PR DESCRIPTION
#59 の問題を解決してみました。

もし `hbfav2://page/open/http://example.com/` がクールなURLでないと思われた場合は変更してください。
ブックマークレットが下記のものになる以外は、動作確認の方法は前回と同じです。

`javascript:window.location='hbfav2://page/open/'+window.location`
