### PR TITLE
Update motion-cocoapods in order to fix build error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     fuzzy_match (2.0.4)
     i18n (0.6.9)
     json_pure (1.8.1)
-    motion-cocoapods (1.3.6)
+    motion-cocoapods (1.4.0)
       cocoapods (>= 0.17.0)
     motion-require (0.0.6)
     motion-testflight (1.5)


### PR DESCRIPTION
This patch should fix the following build error.

```
% bundle exec rake
Could not find rake-10.1.0 in any of the sources
Run `bundle install` to install missing gems.
rake aborted!
[!] Unable to satisfy the following requirements:
- `TTTAttributedLabel (from `git@github.com:mattt/TTTAttributedLabel.git`)` required by `Podfile`
/Users/watson/src/github/HBFav2/Rakefile:60:in `block in <top (required)>'
/Library/RubyMotion/lib/motion/project/config.rb:109:in `call'
/Library/RubyMotion/lib/motion/project/config.rb:109:in `block in setup'
/Library/RubyMotion/lib/motion/project/config.rb:109:in `each'
/Library/RubyMotion/lib/motion/project/config.rb:109:in `setup'
/Library/RubyMotion/lib/motion/project/app.rb:64:in `config'
/Library/RubyMotion/lib/motion/project/template/ios.rb:44:in `block (2 levels) in <top (required)>'
/Library/RubyMotion/lib/motion/project/template/ios.rb:63:in `block in <top (required)>'
Tasks: TOP => build:simulator
(See full trace by running task with --trace)
```

https://github.com/naoya/HBFav2/commit/6acf1d48f4f27b6f18d1af98d63afc74bffcc141 で CocoaPods のバージョンを上げられたことで、motion-cocoapods と整合性がとれずにビルドに失敗するようです。
