### PR TITLE
remove/update SDKs which uses AdSupport.framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ vendor/ChromeProgressBar/*.bridgesupport
 vendor/Parse 3.framework/build-*
 vendor/TestFlightSDK2.0.0/build-*
 
+vendor/ParseDummy/build-*
+vendor/ParseDummy/*.bridgesupport
+
 ### /Users/naoya/.gitignore-boilerplates/ruby.gitignore
 
 *.gem

--- a/Rakefile
+++ b/Rakefile
@@ -73,9 +73,6 @@ Motion::Project::App.setup do |app|
     pod 'HatenaBookmarkSDK', :git => 'git@github.com:hatena/Hatena-Bookmark-iOS-SDK.git'
     pod 'MPNotificationView'
     pod 'GoogleAnalytics-iOS-SDK'
-
-    ## Parse.com SDK が依存してるけど本来必要ない。現状、解決されてない様子
-    pod 'Facebook-iOS-SDK'
   end
 
   app.frameworks += ['ImageIO', 'MapKit', 'Security', 'AVFoundation']
@@ -109,6 +106,13 @@ Motion::Project::App.setup do |app|
     :static,
     :products => ['Parse'],
     :headers_dir => 'Headers'
+  )
+
+  ## ParseDummy
+  # http://stackoverflow.com/questions/15457136/parse-for-ios-errors-when-trying-to-run-the-app/18626232#18626232
+  app.vendor_project(
+    'vendor/ParseDummy',
+    :static
   )
 
   ## Reveal

--- a/vendor/ParseDummy/ParseDummy.m
+++ b/vendor/ParseDummy/ParseDummy.m
@@ -1,0 +1,26 @@
+// http://stackoverflow.com/questions/15457136/parse-for-ios-errors-when-trying-to-run-the-app/18626232#18626232
+#import <Foundation/Foundation.h>
+
+NSString *FBTokenInformationExpirationDateKey = @"";
+NSString *FBTokenInformationTokenKey = @"";
+NSString *FBTokenInformationUserFBIDKey = @"";
+@interface FBAppCall:NSObject
+@end
+@implementation FBAppCall
+@end
+@interface FBRequest:NSObject
+@end
+@implementation FBRequest
+@end
+@interface FBSession:NSObject
+@end
+@implementation FBSession
+@end
+@interface FBSessionTokenCaching:NSObject
+@end
+@implementation FBSessionTokenCaching
+@end
+@interface FBSessionTokenCachingStrategy:NSObject
+@end
+@implementation FBSessionTokenCachingStrategy
+@end

--- a/vendor/Podfile.lock
+++ b/vendor/Podfile.lock
@@ -2,7 +2,6 @@ PODS:
   - AFNetworking (1.3.2)
   - ARChromeActivity (1.0.1)
   - BugSense (3.4)
-  - Facebook-iOS-SDK (3.7.0)
   - GoogleAnalytics-iOS-SDK (3.0.3c)
   - HatenaBookmarkSDK (1.1.1):
     - AFNetworking (~> 1.0)
@@ -23,7 +22,6 @@ DEPENDENCIES:
   - AFNetworking (~> 1.3)
   - ARChromeActivity
   - BugSense
-  - Facebook-iOS-SDK
   - GoogleAnalytics-iOS-SDK
   - HatenaBookmarkSDK (from `git@github.com:hatena/Hatena-Bookmark-iOS-SDK.git`)
   - ISBackGesture (from `https://github.com/ishkawa/ISBackGesture.git`)
@@ -52,7 +50,6 @@ SPEC CHECKSUMS:
   AFNetworking: 7f9bcd7c287a75476cd5c61e82fd3380e93e4c54
   ARChromeActivity: eb9770a933cfe2b914b8e4e22b684eb7f43f24df
   BugSense: 0b0f27d15f29e7b7ff0b56b4f7511ad6999b3cea
-  Facebook-iOS-SDK: 39b55f6c2a8901df8ebcfa23b90c66da1c475f82
   GoogleAnalytics-iOS-SDK: a1dc8c700de9edf41f57c0abe54a7eb2182a1820
   HatenaBookmarkSDK: 2447855afdf5e36131ca7a4f1c57a5e52983664c
   ISBackGesture: 8d67984a799b5a70abf569e5c184113129c4270d


### PR DESCRIPTION
AdSupport.framework を利用している SDK を使っていると、Apple のレビューでにリジェクトされるようになったらしいです。

詳細は、 http://qiita.com/monry/items/b473e3db7e48f05be96b あたりを参照してください。
