### PR TITLE
Fix crush action menu #98

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-$:.unshift("/Library/RubyMotion/lib")
+$:.unshift("/Library/RubyMotion2.30/lib")
 require 'motion/project/template/ios'
 require 'bundler/setup'
 Bundler.require :default


### PR DESCRIPTION
ひとまず RubyMotion 2.30 を利用することでバグを回避。
修正バージョンが出たらもとに戻す。

```
$ sudo motion update --cache-version=2.30
```

が事前に必要。
