### PR TITLE
ios7? メソッドを ios7_or_later? メソッドに変更

### DIFF
--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -39,7 +39,7 @@ class AppDelegate
   end
 
   def configure_status_bar
-    if UIDevice.currentDevice.ios7?
+    if UIDevice.currentDevice.ios7_or_later?
       UIApplication.sharedApplication.setStatusBarStyle(UIStatusBarStyleLightContent)
     else
       UIApplication.sharedApplication.setStatusBarStyle(UIStatusBarStyleBlackOpaque)
@@ -157,7 +157,7 @@ class AppDelegate
   end
 
   def configure_navigation_bar
-    if UIDevice.currentDevice.ios7?
+    if UIDevice.currentDevice.ios7_or_later?
       UINavigationBar.appearance.barTintColor = UIColor.colorWithRed(0.3647, green:0.6431, blue:0.8627, alpha:1.0)
       UINavigationBar.appearance.titleTextAttributes = {
         NSForegroundColorAttributeName => UIColor.whiteColor,
@@ -171,7 +171,7 @@ class AppDelegate
   end
 
   def configure_bar_button_item
-    unless UIDevice.currentDevice.ios7?
+    unless UIDevice.currentDevice.ios7_or_later?
       background_image = UIImage.imageNamed("UIBarButtonItemBarBackGround.png")
       UIBarButtonItem.appearanceWhenContainedIn(UINavigationBar, nil).setBackgroundImage(background_image, forState:UIControlStateNormal, barMetrics:UIBarMetricsDefault)
       UIBarButtonItem.appearanceWhenContainedIn(UINavigationBar, nil).setBackButtonBackgroundImage(background_image, forState:UIControlStateNormal, barMetrics:UIBarMetricsDefault)
@@ -179,7 +179,7 @@ class AppDelegate
   end
 
   def configure_background_fetch
-    if UIDevice.currentDevice.ios7?
+    if UIDevice.currentDevice.ios7_or_later?
       NSLog("**** Background Fetch Enabled ****")
       ## FIXME: 定数を使うと iOS6 でクラッシュする
       # UIApplication.sharedApplication.setMinimumBackgroundFetchInterval(UIApplicationBackgroundFetchIntervalMinimum)

--- a/app/cocoa/ui_device.rb
+++ b/app/cocoa/ui_device.rb
@@ -13,15 +13,15 @@ class UIDevice
     return @@gt[version]
   end
 
-  def ios8?
-    gt?("8.0")
-  end
-
-  def ios7?
+  def ios7_or_later?
     gt?("7.0")
   end
 
-  def ios6?
-    !ios7?
+  def ios8_or_later?
+    gt?("8.0")
+  end
+
+  def ios6_or_earlier?
+    !ios7_or_later?
   end
 end

--- a/app/config/application_config.rb
+++ b/app/config/application_config.rb
@@ -8,26 +8,26 @@ class ApplicationConfig
 
   def initialize
     @vars = MY_ENV
-    @is_ios7 = UIDevice.currentDevice.ios7?
+    @is_ios7 = UIDevice.currentDevice.ios7_or_later?
   end
 
-  def ios7?
+  def ios7_or_later?
     @is_ios7
   end
 
   def applicationFontOfSize(size)
-    ios7? ? UIFont.fontWithName("HelveticaNeue", size:size) : UIFont.systemFontOfSize(size)
+    ios7_or_later? ? UIFont.fontWithName("HelveticaNeue", size:size) : UIFont.systemFontOfSize(size)
   end
 
   def boldApplicationFontOfSize(size)
-    ios7? ? UIFont.fontWithName("HelveticaNeue", size:size) : UIFont.boldSystemFontOfSize(size)
+    ios7_or_later? ? UIFont.fontWithName("HelveticaNeue", size:size) : UIFont.boldSystemFontOfSize(size)
   end
 
   def systemFontOfSize(size)
-    ios7? ? UIFont.fontWithName("HelveticaNeue", size:size) : UIFont.systemFontOfSize(size)
+    ios7_or_later? ? UIFont.fontWithName("HelveticaNeue", size:size) : UIFont.systemFontOfSize(size)
   end
 
   def boldSystemFontOfSize(size)
-    ios7? ? UIFont.fontWithName("Helvetica-Bold", size:size) : UIFont.boldSystemFontOfSize(size)
+    ios7_or_later? ? UIFont.fontWithName("Helvetica-Bold", size:size) : UIFont.boldSystemFontOfSize(size)
   end
 end

--- a/app/controller/account_view_controller.rb
+++ b/app/controller/account_view_controller.rb
@@ -10,7 +10,7 @@ class AccountViewController < HBFav2::UIViewController
     self.navigationItem.title = @user.name
     self.tracked_view_name = "Account"
 
-    if UIDevice.currentDevice.ios7?
+    if UIDevice.currentDevice.ios7_or_later?
       self.edgesForExtendedLayout = UIRectEdgeNone
     end
 

--- a/app/controller/app_info_view_controller.rb
+++ b/app/controller/app_info_view_controller.rb
@@ -8,7 +8,7 @@ class AppInfoViewController < HBFav2::UIViewController
     self.title = "アプリについて"
     self.tracked_view_name = "AppInfo"
 
-    if UIDevice.currentDevice.ios7?
+    if UIDevice.currentDevice.ios7_or_later?
       self.edgesForExtendedLayout = UIRectEdgeNone
     end
 

--- a/app/controller/base/hbfav2_navigation_controller.rb
+++ b/app/controller/base/hbfav2_navigation_controller.rb
@@ -23,7 +23,7 @@ class HBFav2NavigationController < UINavigationController
     super
 
     ## naviBar の上部を丸める
-    if not UIDevice.currentDevice.ios7? and self.rounded_corners
+    if not UIDevice.currentDevice.ios7_or_later? and self.rounded_corners
       layer = self.navigationBar.layer
       maskPath = UIBezierPath.bezierPathWithRoundedRect(
         layer.bounds,

--- a/app/controller/base/hbfav2_ui_table_view_controller.rb
+++ b/app/controller/base/hbfav2_ui_table_view_controller.rb
@@ -11,7 +11,7 @@ module HBFav2
       configure_back_gesture
       self.navigationItem.backBarButtonItem = NavigationBackButton.create
 
-      if UIDevice.currentDevice.ios7?
+      if UIDevice.currentDevice.ios7_or_later?
         self.tableView.separatorInset = UIEdgeInsetsMake(0, 20, 0, 0)
         self.tableView.separatorColor = '#ddd'.uicolor
       end

--- a/app/controller/bookmarks_view_controller.rb
+++ b/app/controller/bookmarks_view_controller.rb
@@ -87,7 +87,7 @@ class BookmarksViewController < HBFav2::UITableViewController
     end
   end
 
-  if UIDevice.currentDevice.ios7?
+  if UIDevice.currentDevice.ios7_or_later?
     def tableView(tableView, heightForHeaderInSection:section)
       if @bookmarks.has_popular_bookmarks?
         SectionHeaderView.heightForHeader
@@ -97,7 +97,7 @@ class BookmarksViewController < HBFav2::UITableViewController
     end
 
     def tableView(tableView, viewForHeaderInSection:section)
-      if UIDevice.currentDevice.ios7?
+      if UIDevice.currentDevice.ios7_or_later?
         SectionHeaderView.new.tap do |label|
           label.text = section == 0 ? "人気" : "すべて"
         end

--- a/app/controller/left_view_controller.rb
+++ b/app/controller/left_view_controller.rb
@@ -15,7 +15,7 @@ class LeftViewController < UITableViewController
     self.view.backgroundColor = [41, 47, 59].uicolor
     self.view.backgroundView = nil
 
-    if UIDevice.currentDevice.ios7?
+    if UIDevice.currentDevice.ios7_or_later?
       self.view.separatorStyle = UITableViewCellSeparatorStyleNone
     else
       self.view.separatorColor = [36, 42, 54].uicolor
@@ -58,7 +58,7 @@ class LeftViewController < UITableViewController
     ]
 
     ## FIXME: ステータスバー分を空の row でごまかしている･･･
-    if UIDevice.currentDevice.ios7?
+    if UIDevice.currentDevice.ios7_or_later?
       src.unshift({ :title => "", :blank => true })
     end
 
@@ -78,7 +78,7 @@ class LeftViewController < UITableViewController
   end
 
   def rowForProfile
-    UIDevice.currentDevice.ios7? ? 1 : 0
+    UIDevice.currentDevice.ios7_or_later? ? 1 : 0
   end
 
   def rowForTimeline
@@ -94,7 +94,7 @@ class LeftViewController < UITableViewController
   end
 
   def tableView(tableView, heightForRowAtIndexPath:indexPath)
-    if UIDevice.currentDevice.ios7? and indexPath.row == 0
+    if UIDevice.currentDevice.ios7_or_later? and indexPath.row == 0
       21
     else
       super
@@ -126,7 +126,7 @@ class LeftViewController < UITableViewController
   def observeValueForKeyPath(keyPath, ofObject:object, change:change, context:context)
     if (ApplicationUser.sharedUser == object and keyPath == 'hatena_id')
       ## FIXME: 生データいじりすぎてて微妙
-      row = if UIDevice.currentDevice.ios7?
+      row = if UIDevice.currentDevice.ios7_or_later?
               @dataSource[1]
             else
               @dataSource[0]

--- a/app/controller/module/hbfav2_back_gesture.rb
+++ b/app/controller/module/hbfav2_back_gesture.rb
@@ -1,7 +1,7 @@
 module HBFav2
   module BackGesture
     def configure_back_gesture
-      if UIDevice.currentDevice.ios7?
+      if UIDevice.currentDevice.ios7_or_later?
         self.backGestureEnabled = false
         return
       end

--- a/app/controller/module/hbfav2_full_screenable.rb
+++ b/app/controller/module/hbfav2_full_screenable.rb
@@ -3,7 +3,7 @@ module HBFav2
   module FullScreenable
     def prepare_fullscreen
       @fullscreen = false
-      if UIDevice.currentDevice.ios7?
+      if UIDevice.currentDevice.ios7_or_later?
         # self.extendedLayoutIncludesOpaqueBars = false
       else
         self.navigationController.setToolbarHidden(true, animated:true)
@@ -17,7 +17,7 @@ module HBFav2
 
     def cleanup_fullscreen
       @fullscreen = false
-      unless UIDevice.currentDevice.ios7?
+      unless UIDevice.currentDevice.ios7_or_later?
         self.navigationController.setNavigationBarHidden(false, animated:false)
         self.navigationController.navigationBar.translucent = false
         self.navigationController.toolbar.translucent = false
@@ -38,7 +38,7 @@ module HBFav2
       if navigationController.present?
         @fullscreen = true
 
-        if UIDevice.currentDevice.ios7?
+        if UIDevice.currentDevice.ios7_or_later?
           self.navigationController.setNavigationBarHidden(true, animated:true)
           UIApplication.sharedApplication.setStatusBarHidden(true, withAnimation:UIStatusBarAnimationFade)
         else
@@ -53,7 +53,7 @@ module HBFav2
 
     def end_fullscreen
       @fullscreen = false
-      if UIDevice.currentDevice.ios7?
+      if UIDevice.currentDevice.ios7_or_later?
         self.navigationController.setNavigationBarHidden(false, animated:true)
         UIApplication.sharedApplication.setStatusBarHidden(false, withAnimation:UIStatusBarAnimationFade)
       else

--- a/app/remote_notification_delegate.rb
+++ b/app/remote_notification_delegate.rb
@@ -57,7 +57,7 @@ module HBFav2
 
           ## 他の画面でローカルpushイベントを採れるように、発火
           ## iOS 7 は Background Fetch に任せるので必要ない
-          if UIDevice.currentDevice.ios6?
+          if UIDevice.currentDevice.ios6_or_earlier?
             notify = NSNotification.notificationWithName(
               "applicationDidReceiveRemoteNotification", object:userInfo
             )

--- a/app/util/text_util.rb
+++ b/app/util/text_util.rb
@@ -1,7 +1,7 @@
 module HBFav2
   class TextUtil
     def self.text(text, sizeWithFont:font, constrainedToSize:size, lineBreakMode:lineBreakMode)
-      if UIDevice.currentDevice.ios7?
+      if UIDevice.currentDevice.ios7_or_later?
         frame = text.boundingRectWithSize(
           size,
           options:NSStringDrawingUsesLineFragmentOrigin|NSStringDrawingUsesFontLeading,
@@ -15,7 +15,7 @@ module HBFav2
     end
 
     def self.text(text, drawInRect:rect, withFont:font, color:color, lineBreakMode:lineBreakMode)
-      if UIDevice.currentDevice.ios7?
+      if UIDevice.currentDevice.ios7_or_later?
         context = NSStringDrawingContext.alloc.init
         text.drawWithRect(
           rect,

--- a/app/view/bookmark_fast_cell.rb
+++ b/app/view/bookmark_fast_cell.rb
@@ -143,7 +143,7 @@ class BookmarkFastCell < UITableViewCell
     body_width = self.class.bodyWidth(self.frame.size.width)
     attributes = BookmarkLabelAttributes.sharedAttributes.attributes
 
-    if not UIDevice.currentDevice.ios7? and (self.selected? || self.highlighted?)
+    if not UIDevice.currentDevice.ios7_or_later? and (self.selected? || self.highlighted?)
       color = {
         :date => '#fff',
         :text => '#fff',

--- a/app/view/bookmark_view.rb
+++ b/app/view/bookmark_view.rb
@@ -34,7 +34,7 @@ module HBFav2
         @nameLabel = UILabel.new.tap do |v|
           v.frame = CGRectZero
           v.font = ApplicationConfig.sharedConfig.boldApplicationFontOfSize(18)
-          unless UIDevice.currentDevice.ios7?
+          unless UIDevice.currentDevice.ios7_or_later?
             v.shadowColor = UIColor.whiteColor
             v.shadowOffset = [0, 1]
           end
@@ -127,7 +127,7 @@ module HBFav2
 
         @bodyView << @usersButton = UIButton.buttonWithType(UIButtonTypeRoundedRect).tap do |button|
           button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft
-          if UIDevice.currentDevice.ios7?
+          if UIDevice.currentDevice.ios7_or_later?
             button.contentEdgeInsets = UIEdgeInsetsMake(0, 15, 0, 0)
             button.titleLabel.font = ApplicationConfig.sharedConfig.systemFontOfSize(18)
           else
@@ -135,7 +135,7 @@ module HBFav2
           end
         end
 
-        if UIDevice.currentDevice.ios7?
+        if UIDevice.currentDevice.ios7_or_later?
           @usersButtonBorderTop = UIView.new.tap do |v|
             v.backgroundColor = '#ddd'.uicolor
             @bodyView << v
@@ -312,7 +312,7 @@ module HBFav2
       # button
       @usersButton.frame = [[10, @dateLabel.bottom + 10], [self.frame.size.width - 20, 40]]
 
-      if UIDevice.currentDevice.ios7?
+      if UIDevice.currentDevice.ios7_or_later?
         @usersButtonBorderTop.frame    = [[15, @usersButton.top], [self.right - 30, 1]]
         @usersButtonBorderBottom.frame = [[15, @usersButton.bottom], [self.right - 30, 1]]
       end

--- a/app/view/hbfav2_custom_cell_content_view.rb
+++ b/app/view/hbfav2_custom_cell_content_view.rb
@@ -1,9 +1,9 @@
 module HBFav2
   class CustomCellContentView < UIView
     def drawRect(rect)
-      if UIDevice.currentDevice.ios8?
+      if UIDevice.currentDevice.ios8_or_later?
         self.superview.superview.drawRectContent(rect)
-      elsif UIDevice.currentDevice.ios7?
+      elsif UIDevice.currentDevice.ios7_or_later?
         self.superview.superview.superview.drawRectContent(rect)
       else
         self.superview.superview.drawRectContent(rect)

--- a/app/view/hotentry_cell.rb
+++ b/app/view/hotentry_cell.rb
@@ -134,7 +134,7 @@ class HotentryCell < UITableViewCell
   def drawRectContent(rect)
     attributes = BookmarkLabelAttributes.sharedAttributes.attributes
 
-    if not UIDevice.currentDevice.ios7? and (self.selected? || self.highlighted?)
+    if not UIDevice.currentDevice.ios7_or_later? and (self.selected? || self.highlighted?)
       color = {
         :date => '#fff',
         :text => '#fff',

--- a/app/view/left_view_cell.rb
+++ b/app/view/left_view_cell.rb
@@ -63,13 +63,13 @@ class LeftViewCell < UITableViewCell
     size =  @title.sizeWithFont(ApplicationConfig.sharedConfig.applicationFontOfSize(18))
     title = @title.attrd.foreground_color([196, 204, 217].uicolor).font(ApplicationConfig.sharedConfig.applicationFontOfSize(18))
 
-    if not UIDevice.currentDevice.ios7?
+    if not UIDevice.currentDevice.ios7_or_later?
       title = title.shadow(@titleShadow)
     end
 
     title.drawInRect([[self.imageView.right + 8, self.imageView.top + 4], size])
 
-    if UIDevice.currentDevice.ios7?
+    if UIDevice.currentDevice.ios7_or_later?
       unless selected?
         context = UIGraphicsGetCurrentContext()
         [36, 42, 54].uicolor(1.0).setStroke

--- a/app/view/navigationbar_back_button.rb
+++ b/app/view/navigationbar_back_button.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 class NavigationBackButton < UIBarButtonItem
   def self.create
-    if UIDevice.currentDevice.ios7?
+    if UIDevice.currentDevice.ios7_or_later?
       UIBarButtonItem.titled("")
     else
       UIBarButtonItem.titled("戻る")

--- a/app/view/readability_bar_button_item.rb
+++ b/app/view/readability_bar_button_item.rb
@@ -2,7 +2,7 @@ class ReadabilityBarButtonItem < UIBarButtonItem
   def initWithTarget(target, action:action)
     self.initWithCustomView(
       UIButton.custom.tap do |btn|
-        if UIDevice.currentDevice.ios7?
+        if UIDevice.currentDevice.ios7_or_later?
           btn.frame = [[0, 0], [24, 24]]
           btn.setImage(UIImage.imageNamed('readability-ios7'), forState: :normal.uicontrolstate)
         else

--- a/app/view/refresh_control.rb
+++ b/app/view/refresh_control.rb
@@ -4,7 +4,7 @@ module HBFav2
     def init
       super
       if self
-        if UIDevice.currentDevice.ios7?
+        if UIDevice.currentDevice.ios7_or_later?
           self.backgroundColor = '#e2e7ed'.uicolor
         end
       end
@@ -12,7 +12,7 @@ module HBFav2
     end
 
     def update_title(msg = nil)
-      unless UIDevice.currentDevice.ios7?
+      unless UIDevice.currentDevice.ios7_or_later?
         color = "#678"
         shadow = NSShadow.new
         shadow.shadowOffset = [0, 1]

--- a/app/view/title_label.rb
+++ b/app/view/title_label.rb
@@ -6,7 +6,7 @@ class TitleLabel < UILabel
       self.textAlignment = UITextAlignmentCenter
       self.textColor = UIColor.whiteColor
 
-      unless UIDevice.currentDevice.ios7?
+      unless UIDevice.currentDevice.ios7_or_later?
         self.shadowColor = UIColor.colorWithWhite(0.0, alpha: 0.5)
       end
     end


### PR DESCRIPTION
`ios7?` はこれまで「ios7以上」の意味のメソッドだったが名前は `ios7?` で正確に実態を表していなかった。
iOS 8 がリリースされたことにより、この問題が顕在化したので、リファクタリングして fix
