### PR TITLE
RSSフィード取得処理に 25秒のタイムアウトを設ける

### DIFF
--- a/app/model/feed_manager.rb
+++ b/app/model/feed_manager.rb
@@ -49,9 +49,10 @@ class FeedManager
           prepend ? self.prepend(bookmarks) : self.append(bookmarks)
           self.didChangeValueForKey('bookmarks')
         else
-          Dispatch::Queue.main.async {
-            App.alert(response.error_message)
-          }
+          ## 触っててウザいので出さない
+          # Dispatch::Queue.main.async {
+          #   App.alert(response.error_message)
+          # }
         end
         Dispatch::Queue.main.async {
           @updating = false


### PR DESCRIPTION
Background Fetch は 30 sec 以内に処理が終了しないとアプリが Terminate されてしまうので、25 秒くらいたっても応答がなかったらそこで処理を切り上げる。

あと、リクエストが失敗したときにユーザーにエラーでそれと分かるように通知する。ただこっちは以前にそうしてたけどウザいから止めたような記憶があるのでしばらく dog fooding してチェック
