### PR TITLE
SDK 認証切れ問題対応の ad hoc 修正

### DIFF
--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -3,6 +3,7 @@ class AppDelegate
   attr_accessor :viewController, :timelineViewController, :bookmarksViewController, :hotentryViewController, :entrylistViewController
   include HBFav2::RemoteNotificationDelegate
   include HBFav2::GoogleAnalytics
+  include HBFav2::HatenaBookmarkSDK
 
   def application(application, didFinishLaunchingWithOptions:launchOptions)
     NSLog("RUBYMOTION_ENV: " + RUBYMOTION_ENV)
@@ -10,7 +11,7 @@ class AppDelegate
     app_config = ApplicationConfig.sharedConfig
 
     self.configure_pocket_service(app_config)
-    self.configure_hatena_bookmark_service(app_config)
+    self.configure_hatena_bookmark_service
     self.configure_google_api_service(app_config)
     self.configure_google_analytics(app_config.vars['google_analytics']['tracking_id'])
     self.configure_parse_service(app_config, launchOptions)
@@ -117,13 +118,6 @@ class AppDelegate
   def configure_pocket_service(app_config)
     PocketAPI.sharedAPI.setConsumerKey(
       app_config.vars["pocket"]["consumer_key"]
-    )
-  end
-
-  def configure_hatena_bookmark_service(app_config)
-    HTBHatenaBookmarkManager.sharedManager.setConsumerKey(
-      app_config.vars['hatena']['consumer_key'],
-      consumerSecret:app_config.vars['hatena']['consumer_secret']
     )
   end
 

--- a/app/controller/bookmark_view_controller.rb
+++ b/app/controller/bookmark_view_controller.rb
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 class BookmarkViewController < HBFav2::UIViewController
+  include HBFav2::HatenaBookmarkSDK
+
   attr_accessor :bookmark, :url, :short_url, :user_name, :on_modal
 
   def viewDidLoad
@@ -136,6 +138,7 @@ class BookmarkViewController < HBFav2::UIViewController
   end
 
   def open_hatena_bookmark_view
+    configure_hatena_bookmark_service
     controller = HTBHatenaBookmarkViewController.alloc.init
     controller.URL = @bookmark.link.nsurl
     self.presentViewController(controller, animated:true, completion:nil)

--- a/app/controller/web_view_controller.rb
+++ b/app/controller/web_view_controller.rb
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 class WebViewController < HBFav2::UIViewController
+  include HBFav2::HatenaBookmarkSDK
+
   attr_accessor :bookmark, :on_modal
 
   def viewDidLoad
@@ -225,6 +227,7 @@ class WebViewController < HBFav2::UIViewController
   end
 
   def open_hatena_bookmark_view
+    configure_hatena_bookmark_service
     controller = HTBHatenaBookmarkViewController.alloc.init
     controller.URL = @bookmark.link.nsurl
     self.presentViewController(controller, animated:true, completion:nil)

--- a/app/util/hatena_bookmark_sdk.rb
+++ b/app/util/hatena_bookmark_sdk.rb
@@ -1,0 +1,11 @@
+module HBFav2
+  module HatenaBookmarkSDK
+    def configure_hatena_bookmark_service
+      config = ApplicationConfig.sharedConfig
+      HTBHatenaBookmarkManager.sharedManager.setConsumerKey(
+        config.vars['hatena']['consumer_key'],
+        consumerSecret:config.vars['hatena']['consumer_secret'],
+      )
+    end
+  end
+end


### PR DESCRIPTION
#112 を受けて、初期化処理ががタイミングによって呼ばれていない可能性が出てきたので、ブックマーク追加画面起動時に初期化処理を明示的に呼んでやるようにしてみる。

ad hoc ではありますが。

しばらくこれで様子を見てみる。
