### PR TITLE
Remove unnecessary configuration related to hide nocomment bookmarks

### DIFF
--- a/app/controller/account_config_view_controller.rb
+++ b/app/controller/account_config_view_controller.rb
@@ -34,12 +34,6 @@ class AccountConfigViewController < Formotion::FormController
               title: "オプション",
               rows: [
                 {
-                  title: "コメントなしブックマークを非表示",
-                  key: 'hide_nocomment_bookmarks',
-                  type: 'switch',
-                  value: user.hide_nocomment_bookmarks?
-                },
-                {
                   title: "新ユーザーページ",
                   key: 'use_timeline',
                   type: 'switch',


### PR DESCRIPTION
https://github.com/naoya/HBFav2/pull/120 で設定を移動したつもりだったのですが、「はてなアカウント」のページに残っていたので消しました（以下の画像の設定項目）。
![141204-0003.png](https://qiita-image-store.s3.amazonaws.com/0/2075/261edb25-0a8b-d361-ca04-6279e159c636.png)
