### PR TITLE
fix encoding name in order to fix build error with Ruby 2.2.0-rc1

### DIFF
--- a/app/cocoa/ns_string.rb
+++ b/app/cocoa/ns_string.rb
@@ -1,4 +1,4 @@
-# -*- coding: undecided -*-
+# -*- coding: utf-8 -*-
 class NSString
   def truncate(truncate_at, options = {})
     return dup unless length > truncate_at

--- a/app/controller/base/hbfav2_ui_view_controller.rb
+++ b/app/controller/base/hbfav2_ui_view_controller.rb
@@ -1,4 +1,4 @@
-# -*- coding: undecided -*-
+# -*- coding: utf-8 -*-
 module HBFav2
   class UIViewController < UIViewController
     attr_accessor :tracked_view_name


### PR DESCRIPTION
Ruby 2.2.0-rc1を使用してビルドすると、以下のようなエラーが起きます。

```
$ bundle exec rake
     Build ./build/iPhoneSimulator-7.0-Development
     Build vendor/Bolts.framework
     Build vendor/Parse.framework
rake aborted!
ArgumentError: unknown encoding name: undecided
```

RubyMotionのビルドシステムでファイルの依存関係を構築するのに`ripper`というライブラリを利用しています。
これの振る舞いがRuby 2.2.0-rc1で変わったみたいで、エンコーディングにundecidedを指定するとエラーになってしまうので修正しています。
