### PR TITLE
[WIP] ハンバーガーメニューをやめてタブに変更

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ Motion::Project::App.setup do |app|
   app.name = 'HBFav'
   app.version = "2.8.2"
   app.short_version = "2.8.2"
-  app.sdk_version = '8.1'
+  app.sdk_version = '8.3'
   app.deployment_target = '7.0'
   app.device_family = [:iphone]
   app.identifier = "HBFav"

--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -45,21 +45,37 @@ class AppDelegate
   def initialize_window
     app_user   = ApplicationUser.sharedUser.load
 
+#    @viewController = HBFav2PanelController.sharedController
+#    @viewController.leftGapPercentage = 0.7
+#
+#    @leftViewController = LeftViewController.new
+#    @leftViewController.controllers = self.initialize_view_controllers(app_user)
+#    @viewController.leftPanel = @leftViewController
+#
+#    @viewController.centerPanel = HBFav2NavigationController.alloc.initWithRootViewController(
+#      @timelineViewController
+#    )
+
+    @tabBarController = UITabBarController.alloc.init
+    @tabBarController.viewControllers = self.initialize_view_controllers(app_user)
+
+    tabBar = @tabBarController.tabBar
+    tabBar.setTranslucent(false)
+
+    tabBar.items[0].title = "タイムライン"
+    tabBar.items[0].image = UIImage.imageNamed('insignia_star')
+
+    tabBar.items[1].title = "ブックマーク"
+    tabBar.items[1].image = UIImage.imageNamed('insignia_tags')
+
+    tabBar.items[2].title = "人気"
+    tabBar.items[2].image = UIImage.imageNamed('insignia_heart')
+    
+    tabBar.items[3].title = "新着"
+    tabBar.items[3].image = UIImage.imageNamed('insignia_file')
+
     @window = UIWindow.alloc.initWithFrame(UIScreen.mainScreen.bounds)
-
-    view_controllers = self.initialize_view_controllers(app_user)
-
-    @viewController = HBFav2PanelController.sharedController
-    @viewController.leftGapPercentage = 0.7
-
-    @leftViewController = LeftViewController.new
-    @leftViewController.controllers = view_controllers
-    @viewController.leftPanel = @leftViewController
-
-    @viewController.centerPanel = HBFav2NavigationController.alloc.initWithRootViewController(
-      @timelineViewController
-    )
-    @window.rootViewController = @viewController
+    @window.rootViewController = @tabBarController
     @window.makeKeyAndVisible
   end
 
@@ -89,17 +105,18 @@ class AppDelegate
       c.as_home   = true
     end
 
-    @accountViewController = AccountViewController.new.tap { |c| c.as_home = true }
-    @appInfoViewController = AppInfoViewController.new.tap { |c| c.as_home = true }
+#    @accountViewController = AccountViewController.new.tap { |c| c.as_home = true }
+#    @appInfoViewController = AppInfoViewController.new.tap { |c| c.as_home = true }
 
-    return {
-      :timeline  => @timelineViewController,
-      :bookmarks => @bookmarksViewController,
-      :hotentry  => @hotentryViewController,
-      :entrylist => @entrylistViewController,
-      :account   => @accountViewController,
-      :appInfo   => @appInfoViewController,
-    }
+    return NSArray.arrayWithObjects(
+      HBFav2NavigationController.alloc.initWithRootViewController(@timelineViewController),
+      HBFav2NavigationController.alloc.initWithRootViewController(@bookmarksViewController),
+      HBFav2NavigationController.alloc.initWithRootViewController(@hotentryViewController),
+      HBFav2NavigationController.alloc.initWithRootViewController(@entrylistViewController),
+#      :account   => @accountViewController,
+#      :appInfo   => @appInfoViewController,
+      nil
+    )
   end
 
   def development?

--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -56,7 +56,7 @@ class AppDelegate
 #      @timelineViewController
 #    )
 
-    @tabBarController = UITabBarController.alloc.init
+    @tabBarController = HBFav2::UITabBarController.alloc.init
     @tabBarController.viewControllers = self.initialize_view_controllers(app_user)
 
     tabBar = @tabBarController.tabBar

--- a/app/controller/account_view_controller.rb
+++ b/app/controller/account_view_controller.rb
@@ -70,6 +70,12 @@ class AccountViewController < HBFav2::UIViewController
 
   def viewWillAppear(animated)
     super
+    
+    self.navigationItem.leftBarButtonItem = UIBarButtonItem.stop.tap do |btn|
+      btn.action = 'on_close'
+      btn.target = self
+    end
+    
     self.navigationController.setToolbarHidden(true, animated:animated)
     self.initialize_data_source
 
@@ -182,6 +188,10 @@ class AccountViewController < HBFav2::UIViewController
     viewController = HTBLoginWebViewController.alloc.initWithAuthorizationRequest(req)
     navigationController.viewControllers = [viewController]
     self.presentViewController(navigationController, animated:true, completion:nil)
+  end
+
+  def on_close
+    self.dismissViewControllerAnimated(true, completion:nil)
   end
 
   def dealloc

--- a/app/controller/account_view_controller.rb
+++ b/app/controller/account_view_controller.rb
@@ -64,6 +64,16 @@ class AccountViewController < HBFav2::UIViewController
             :accessoryType => PocketAPI.sharedAPI.loggedIn? ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone
           },
         ]
+      },
+      {
+        :title => "インフォメーション",
+        :rows => [
+          {
+            :label  => "アプリについて",
+            :action => 'open_app_info',
+            :accessoryType => UITableViewCellAccessoryDisclosureIndicator
+          },
+        ]
       }
     ]
   end
@@ -130,25 +140,6 @@ class AccountViewController < HBFav2::UIViewController
     )
   end
 
-  def open_website
-    bookmark = Bookmark.new({
-      :title => 'HBFav2',
-      :link  => 'http://hbfav.bloghackers.net/',
-      :count => nil
-    })
-    controller = WebViewController.new
-    controller.bookmark = bookmark
-    self.navigationController.pushViewController(controller, animated:true)
-  end
-
-  def open_review
-    "http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=477950722&pageNumber=0&sortOrdering=1&type=Purple+Software&mt=8".nsurl.open
-  end
-
-  def open_report
-    "https://github.com/naoya/HBFav2/issues?state=open".nsurl.open
-  end
-
   def open_hatena
     if HTBHatenaBookmarkManager.sharedManager.authorized
       self.navigationController.pushViewController(HatenaConfigViewController.alloc.initWithStyle(UITableViewStyleGrouped), animated:true)
@@ -179,6 +170,11 @@ class AccountViewController < HBFav2::UIViewController
         end
       )
     end
+  end
+
+  def open_app_info
+    controller = AppInfoViewController.new
+    self.navigationController.pushViewController(controller, animated:true)
   end
 
   def showOAuthLoginView(notification)

--- a/app/controller/base/hbfav2_ui_tabbar_controller.rb
+++ b/app/controller/base/hbfav2_ui_tabbar_controller.rb
@@ -1,0 +1,26 @@
+module HBFav2
+  class UITabBarController < UITabBarController
+    def viewDidLoad
+      super
+      self.delegate = self
+    end
+
+    #
+    # UITabBarControllerDelegate
+    #
+    def tabBarController(tabBarController, didSelectViewController:viewController)
+      @previousController = @previousController || viewController
+      if (@previousController == viewController)
+        if viewController.kind_of?(UINavigationController)
+          if (viewController.viewControllers.count == 1)
+            rootViewController = viewController.viewControllers.firstObject
+            if rootViewController.respondsToSelector('tableView')
+              rootViewController.tableView.setContentOffset(CGPointMake(0, -rootViewController.tableView.contentInset.top), animated:true)
+            end
+          end
+        end
+      end
+      @previousController = viewController
+    end
+  end
+end

--- a/app/controller/bookmark_view_controller.rb
+++ b/app/controller/bookmark_view_controller.rb
@@ -8,7 +8,6 @@ class BookmarkViewController < HBFav2::UIViewController
     self.navigationItem.title = "ブックマーク"
     self.tracked_view_name = "Bookmark"
     self.view.backgroundColor = UIColor.whiteColor
-    self.configure_toolbar
 
     self.view << @bookmarkView = HBFav2::BookmarkView.new.tap do |v|
       v.frame = self.view.bounds
@@ -22,9 +21,6 @@ class BookmarkViewController < HBFav2::UIViewController
     end
 
     self.view << @indicator = UIActivityIndicatorView.gray
-
-    ## clickable URL に悪影響を与えるので中止
-    # self.view.addGestureRecognizer(UITapGestureRecognizer.alloc.initWithTarget(self, action:'toggle_toolbar'))
 
     if self.on_modal == true
       UIBarButtonItem.stop.tap do |btn|
@@ -64,6 +60,7 @@ class BookmarkViewController < HBFav2::UIViewController
   def open_webview
     controller = WebViewController.new
     controller.bookmark = @bookmark
+    controller.hidesBottomBarWhenPushed = true
     self.navigationController.pushViewController(controller, animated: true)
   end
 
@@ -74,7 +71,7 @@ class BookmarkViewController < HBFav2::UIViewController
 
   def viewWillAppear(animated)
     super
-    self.navigationController.setToolbarHidden(false, animated:self.on_modal ? false : true)
+    self.navigationController.setToolbarHidden(true, animated:animated)
 
     if self.bookmark.present?
       @bookmarkView.bookmark = self.bookmark
@@ -104,32 +101,21 @@ class BookmarkViewController < HBFav2::UIViewController
     end
   end
 
-  def toggle_toolbar
-    if @toolbar_visible
-      @toolbar_visible = false
-      self.navigationController.setToolbarHidden(true, animated:true)
-    else
-      @toolbar_visible = true
-      self.navigationController.setToolbarHidden(false, animated:true)
-    end
-  end
-
   def viewWillDisappear(animated)
     super
-    self.navigationController.toolbar.translucent = false
   end
 
-  def configure_toolbar
-    spacer = UIBarButtonItem.fixedspace
-    spacer.width = self.view.size.width - 110
-    self.toolbarItems = [
-      spacer,
-      UIBarButtonItem.alloc.initWithBarButtonSystemItem(UIBarButtonSystemItemCompose, target:self, action: 'on_bookmark'),
-      UIBarButtonItem.flexiblespace,
-      # BookmarkBarButtonItem.alloc.initWithTarget(self, action:'on_bookmark'),
-      UIBarButtonItem.alloc.initWithBarButtonSystemItem(UIBarButtonSystemItemAction, target:self, action:'on_action'),
-    ]
-  end
+  # def configure_toolbar
+  #   spacer = UIBarButtonItem.fixedspace
+  #   spacer.width = self.view.size.width - 110
+  #   self.toolbarItems = [
+  #     spacer,
+  #     UIBarButtonItem.alloc.initWithBarButtonSystemItem(UIBarButtonSystemItemCompose, target:self, action: 'on_bookmark'),
+  #     UIBarButtonItem.flexiblespace,
+  #     # BookmarkBarButtonItem.alloc.initWithTarget(self, action:'on_bookmark'),
+  #     UIBarButtonItem.alloc.initWithBarButtonSystemItem(UIBarButtonSystemItemAction, target:self, action:'on_action'),
+  #   ]
+  # end
 
   def on_bookmark
     open_hatena_bookmark_view
@@ -175,15 +161,11 @@ class BookmarkViewController < HBFav2::UIViewController
     )
     controller = WebViewController.new
     controller.bookmark = bookmark
+    controller.hidesBottomBarWhenPushed = true
     self.navigationController.pushViewController(controller, animated:true)
   end
 
   def on_close
     self.dismissModalViewControllerAnimated(true, completion:nil)
-  end
-
-  def dealloc
-    NSLog("dealloc: " + self.class.name)
-    super
   end
 end

--- a/app/controller/hotentry_view_controller.rb
+++ b/app/controller/hotentry_view_controller.rb
@@ -34,6 +34,7 @@ class HotentryViewController < HBFav2::UITableViewController
       bookmark = @bookmarks[indexPath.row]
       controller = WebViewController.new
       controller.bookmark = bookmark
+      controller.hidesBottomBarWhenPushed = true
       self.navigationController.pushViewController(controller, animated:true)
     end
   end
@@ -128,6 +129,7 @@ class HotentryViewController < HBFav2::UITableViewController
   def tableView(tableView, didSelectRowAtIndexPath:indexPath)
     WebViewController.new.tap do |c|
       c.bookmark = @bookmarks[indexPath.row]
+      c.hidesBottomBarWhenPushed = true
       self.navigationController.pushViewController(c, animated:true)
     end
   end

--- a/app/controller/timeline_view_controller.rb
+++ b/app/controller/timeline_view_controller.rb
@@ -198,6 +198,11 @@ class TimelineViewController < HBFav2::UITableViewController
   end
 
   def viewWillAppear(animated)
+    self.navigationItem.rightBarButtonItem = UIBarButtonItem.titled("設定").tap do |btn|
+      btn.target = self
+      btn.action = 'open_account_config_with_allow_cancellation'
+    end
+    
     self.update_title
     self.navigationController.setToolbarHidden(true, animated:true)
     tableView.reloadDataWithDeselectingRowAnimated(animated)
@@ -248,12 +253,18 @@ class TimelineViewController < HBFav2::UITableViewController
     end
   end
 
-  def open_account_config
-    controller = AccountConfigViewController.new.tap { |c| c.allow_cancellation = false }
+  def open_account_config(allow_cancellation = false)
+    controller = AccountConfigViewController.new.tap { 
+      |c| c.allow_cancellation = allow_cancellation 
+    }
     self.presentModalViewController(
       UINavigationController.alloc.initWithRootViewController(controller),
       animated:true
     )
+  end
+
+  def open_account_config_with_allow_cancellation
+    open_account_config(true)
   end
 
   def on_refresh

--- a/app/controller/timeline_view_controller.rb
+++ b/app/controller/timeline_view_controller.rb
@@ -200,7 +200,7 @@ class TimelineViewController < HBFav2::UITableViewController
   def viewWillAppear(animated)
     self.navigationItem.rightBarButtonItem = UIBarButtonItem.titled("設定").tap do |btn|
       btn.target = self
-      btn.action = 'open_account_config_with_allow_cancellation'
+      btn.action = 'open_account_view'
     end
     
     self.update_title
@@ -263,8 +263,12 @@ class TimelineViewController < HBFav2::UITableViewController
     )
   end
 
-  def open_account_config_with_allow_cancellation
-    open_account_config(true)
+  def open_account_view
+    controller = AccountViewController.new
+    self.presentModalViewController(
+      UINavigationController.alloc.initWithRootViewController(controller),
+      animated:true
+    )    
   end
 
   def on_refresh

--- a/app/controller/timeline_view_controller.rb
+++ b/app/controller/timeline_view_controller.rb
@@ -44,6 +44,7 @@ class TimelineViewController < HBFav2::UITableViewController
       unless bookmark.kind_of? Placeholder
         controller = WebViewController.new
         controller.bookmark = bookmark
+        controller.hidesBottomBarWhenPushed = true
         self.navigationController.pushViewController(controller, animated:true)
       end
     end

--- a/app/controller/web_view_controller.rb
+++ b/app/controller/web_view_controller.rb
@@ -55,11 +55,6 @@ class WebViewController < HBFav2::UIViewController
 
   def viewWillAppear(animated)
     super
-    self.navigationController.toolbar.translucent = false
-    self.navigationController.setToolbarHidden(false, animated:animated)
-
-    ## FIXME: Readability から戻ってくると画面の大きさがおかしくなる
-    @webview.frame = view.frame
     @indicator.center = [ view.center.x, view.center.y + 42 ]
   end
 


### PR DESCRIPTION
![2015-02-08 10 51 59](https://cloud.githubusercontent.com/assets/8991/6094830/8513bfd2-af80-11e4-9a77-e8b414e6fc36.png)

## TODO

- [x] ハンバーガーメニューをやめて UITabBarController を使う
- [ ] app_delegate のリファクタリング
- [x] タブ押したらトップへスクロール
- [x] 設定画面を開くナビゲーション追加
- [x] <del>WebView 開くのをモーダルに変更</del><ins>モーダルは使いづらいのでタブを隠す対応にした</ins>
- [ ] タブバーの見た目 調整
- [ ] HBFav2PanelViewController#presentViewController に相当する機能を追加
- [ ] 不要なコードの削除 (panel_controller, left_view_controller あたり)
- [ ] BookmarkViewController のツールバーにあった機能をどうするか
- [ ] 戻るボタンを長押しするとクラッシュするの fix
- [ ] タブのラベルが「人気」から「人気エントリー」に動的に変わってしまうのをやめたい
- [ ] タブ押してリストに戻ってくるときに元のリスト表示位置を保持したままにしたい
- [ ] URL のところでツールバーで埋もれてる領域がある
- [x] アプリについて画面への動線