### PR TITLE
add configuration to disable App Transport Security

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,6 +38,9 @@ Motion::Project::App.setup do |app|
 
   app.interface_orientations = [:portrait]
 
+  app.info_plist['NSAppTransportSecurity'] = {
+    'NSAllowsArbitraryLoads' => true
+  }
   app.info_plist["UILaunchImages"] = [
     # for iPhone 6 Plus
     {


### PR DESCRIPTION
アプリを iOS 9 SDK を用いてビルドすると App Transport Security のせいで
通信がまったくできなくなるようなので無効にしています。

App Store で配信されている現行のものは iOS 8.x でビルドされているので
iOS 9 デバイスでも動くようです。

iOS 9 SDK でアプリをアップデートする際に、このパッチを使ってみてください。