### PR TITLE
copy TUSafariActivity.bundle manually to avoid motion-cocoapods issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rake'
+gem 'rake-hooks'
 gem 'motion-cocoapods'
 gem 'sugarcube'
 gem "bubble-wrap"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
     netrc (0.7.7)
     open4 (1.3.4)
     rake (10.3.2)
+    rake-hooks (1.2.3)
+      rake
     sugarcube (0.20.25)
     xcodeproj (0.17.0)
       activesupport (~> 3.0)
@@ -72,4 +74,5 @@ DEPENDENCIES
   motion-require
   motion-testflight
   rake
+  rake-hooks
   sugarcube

--- a/Rakefile
+++ b/Rakefile
@@ -137,3 +137,19 @@ Motion::Project::App.setup do |app|
     :headers_dir => 'Headers'
   )
 end
+
+# Workaround for https://github.com/HipByte/motion-cocoapods/issues/122
+after :'build:simulator' do
+  app_path = App.config.app_bundle('iPhoneSimulator')
+  unless File.exist?(File.join(app_path, 'TUSafariActivity.bundle'))
+    App.info 'Copy', 'TUSafariActivity.bundle'
+    cp_r './vendor/Pods/.build/TUSafariActivity.bundle', app_path
+  end
+end
+after :'build:device' do
+  app_path = App.config.app_bundle('iPhoneOS')
+  unless File.exist?(File.join(app_path, 'TUSafariActivity.bundle'))
+    App.info 'Copy', 'TUSafariActivity.bundle'
+    cp_r './vendor/Pods/.build/TUSafariActivity.bundle', app_path
+  end
+end


### PR DESCRIPTION
Related to https://github.com/HipByte/motion-cocoapods/issues/122

クリーンビルドした際に、上記リンクの問題により `TUSafariActivity.bundle` が適切にアプリ内にコピーされないため、
`TUSafariActivity.bundle` をコピーする処理を追加しています。

`TUSafariActivity.bundle` がコピーされないと、`UIActivityViewController` を表示しようとすると
https://github.com/davbeck/TUSafariActivity/blob/master/Pod/Classes/TUSafariActivity.m#L45-L49
でクラッシュしてしまうための対処です。
