### PR TITLE
[fix #128] handle App Store link in webView

### DIFF
--- a/app/controller/web_view_controller.rb
+++ b/app/controller/web_view_controller.rb
@@ -231,6 +231,11 @@ class WebViewController < HBFav2::UIViewController
   end
 
   def webView(webView, shouldStartLoadWithRequest:request, navigationType:navigationType)
+    url = request.URL
+    if url.absoluteString =~ %r{https?://itunes.apple.com}
+      UIApplication.sharedApplication.openURL(url)
+    end
+
     if (navigationType == UIWebViewNavigationTypeLinkClicked)
       @link_clicked = true
     end
@@ -249,6 +254,13 @@ class WebViewController < HBFav2::UIViewController
   end
 
   def webView(webView, decidePolicyForNavigationAction:navigationAction, decisionHandler:decisionHandler)
+    url = navigationAction.request.URL
+    if url.absoluteString =~ %r{https?://itunes.apple.com}
+      UIApplication.sharedApplication.openURL(url)
+      decisionHandler.call(WKNavigationActionPolicyCancel)
+      return
+    end
+
     if navigationAction.navigationType == WKNavigationTypeLinkActivated
       @link_clicked = true
     end


### PR DESCRIPTION
UIWebView と WKWebView の delegate メソッドで処理してあげないとApp Storeは開けないという
謎仕様があり、処理を追加してます。