### PR TITLE
[fix #134] avoid a crash by retaining HTBHatenaBookmarkViewController

### DIFF
--- a/app/controller/bookmark_view_controller.rb
+++ b/app/controller/bookmark_view_controller.rb
@@ -136,9 +136,9 @@ class BookmarkViewController < HBFav2::UIViewController
   end
 
   def open_hatena_bookmark_view
-    controller = HTBHatenaBookmarkViewController.alloc.init
-    controller.URL = @bookmark.link.nsurl
-    self.presentViewController(controller, animated:true, completion:nil)
+    @controller = HTBHatenaBookmarkViewController.alloc.init
+    @controller.URL = @bookmark.link.nsurl
+    self.presentViewController(@controller, animated:true, completion:nil)
   end
 
   def on_action

--- a/app/controller/web_view_controller.rb
+++ b/app/controller/web_view_controller.rb
@@ -198,9 +198,9 @@ class WebViewController < HBFav2::UIViewController
   end
 
   def open_hatena_bookmark_view
-    controller = HTBHatenaBookmarkViewController.alloc.init
-    controller.URL = @bookmark.link.nsurl
-    self.presentViewController(controller, animated:true, completion:nil)
+    @controller = HTBHatenaBookmarkViewController.alloc.init
+    @controller.URL = @bookmark.link.nsurl
+    self.presentViewController(@controller, animated:true, completion:nil)
   end
 
   def on_action


### PR DESCRIPTION
はてなブックマーク SDK によって表示されているダイアログが消えた後でも、
`HTBHatenaBookmarkViewController` 内のオブジェクトが動いているようなので、
次回のダイアログ表示までオブジェクトを保持するようにしました。

試しに変更を加えて丸一日ほどブックマークしまくりクラッシュすることがなかった、
という状態でこれが本当に正しい修正なのか、
はてなブックマーク SDK の問題なのかRubyMotionの問題なのか
を問われても困る感じ・・・m(_ _)m
