### PR TITLE
人気エントリーのカテゴリ閲覧の UI を変更

### DIFF
--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -81,13 +81,13 @@ class AppDelegate
 
     @hotentryViewController = HotentryViewController.new.tap do |c|
       c.list_type = :hotentry
+      c.show_category_button = true
       c.as_home   = true
     end
 
-    @categoryViewController = CategoryViewController.alloc.initWithStyle(UITableViewStyleGrouped)
-
     @entrylistViewController = HotentryViewController.new.tap do |c|
       c.list_type = :entrylist
+      c.show_category_button = true
       c.as_home   = true
     end
 
@@ -98,7 +98,6 @@ class AppDelegate
       :timeline  => @timelineViewController,
       :bookmarks => @bookmarksViewController,
       :hotentry  => @hotentryViewController,
-      :category  => @categoryViewController,
       :entrylist => @entrylistViewController,
       :account   => @accountViewController,
       :appInfo   => @appInfoViewController,

--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -84,6 +84,8 @@ class AppDelegate
       c.as_home   = true
     end
 
+    @categoryViewController = CategoryViewController.alloc.initWithStyle(UITableViewStyleGrouped)
+
     @entrylistViewController = HotentryViewController.new.tap do |c|
       c.list_type = :entrylist
       c.as_home   = true
@@ -96,6 +98,7 @@ class AppDelegate
       :timeline  => @timelineViewController,
       :bookmarks => @bookmarksViewController,
       :hotentry  => @hotentryViewController,
+      :category  => @categoryViewController,
       :entrylist => @entrylistViewController,
       :account   => @accountViewController,
       :appInfo   => @appInfoViewController,

--- a/app/controller/category_view_controller.rb
+++ b/app/controller/category_view_controller.rb
@@ -1,19 +1,11 @@
 # -*- coding: utf-8 -*-
 class CategoryViewController < HBFav2::UITableViewController
-  attr_accessor :current_category, :hotentry_controller
+  attr_accessor :current_category
   def viewDidLoad
     super
     self.title = "カテゴリ"
     self.tracked_view_name = "Category"
     @dataSource = CategoryList.sharedCategories.to_datasource
-  end
-
-  def viewWillAppear(animated)
-    super
-    self.navigationItem.leftBarButtonItem  = UIBarButtonItem.titled("戻る").tap do |btn|
-      btn.action = 'on_close'
-      btn.target = self
-    end
   end
 
   def tableView(tableView, numberOfRowsInSection:indexPath)
@@ -23,16 +15,9 @@ class CategoryViewController < HBFav2::UITableViewController
   def tableView(tableView, cellForRowAtIndexPath:indexPath)
     id = "category-cell"
     row = @dataSource[indexPath.row]
-
     cell = tableView.dequeueReusableCellWithIdentifier(id) ||
       UITableViewCell.alloc.initWithStyle(UITableViewCellStyleDefault, reuseIdentifier:id)
     cell.textLabel.text = row[:title]
-
-    if self.current_category == row[:key]
-      cell.accessoryType = UITableViewCellAccessoryCheckmark
-    else
-      cell.accessoryType = UITableViewCellAccessoryNone
-    end
     cell
   end
 
@@ -47,22 +32,11 @@ class CategoryViewController < HBFav2::UITableViewController
   def tableView(tableView, didSelectRowAtIndexPath:indexPath)
     row = @dataSource[indexPath.row]
     self.current_category = row[:key]
-
-    ## ここでシステムのカテゴリ切り替え
-    # Observer の方がいいかな
-    self.hotentry_controller.category = self.current_category
-    self.hotentry_controller.clear_entries
-    self.dismissViewControllerAnimated(true, completion:lambda do
-      self.hotentry_controller.load_hotentry
-    end)
-  end
-
-  def on_close
-    self.dismissViewControllerAnimated(true, completion:nil)
-  end
-
-  def dealloc
-    NSLog("dealloc: " + self.class.name)
-    super
+    controller = HotentryViewController.new.tap do |c|
+      c.list_type = :hotentry
+      c.as_home   = false
+      c.category  = self.current_category
+    end
+    self.navigationController.pushViewController(controller, animated:true)
   end
 end

--- a/app/controller/category_view_controller.rb
+++ b/app/controller/category_view_controller.rb
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 class CategoryViewController < HBFav2::UITableViewController
-  attr_accessor :current_category
+  attr_accessor :current_category, :list_type
   def viewDidLoad
     super
-    self.title = "カテゴリ"
+    self.title = list_type == :hotentry ? "人気エントリー" : "新着エントリー"
     self.tracked_view_name = "Category"
     @dataSource = CategoryList.sharedCategories.to_datasource
   end
@@ -33,7 +33,7 @@ class CategoryViewController < HBFav2::UITableViewController
     row = @dataSource[indexPath.row]
     self.current_category = row[:key]
     controller = HotentryViewController.new.tap do |c|
-      c.list_type = :hotentry
+      c.list_type = list_type
       c.as_home   = false
       c.category  = self.current_category
     end

--- a/app/controller/hotentry_view_controller.rb
+++ b/app/controller/hotentry_view_controller.rb
@@ -82,15 +82,11 @@ class HotentryViewController < HBFav2::UITableViewController
     self.navigationController.setToolbarHidden(true, animated:animated)
     @indicator.center = [ view.center.x, view.center.y - 42]
 
-    ## category selector
-    label =  CategoryList.sharedCategories.key_to_label(self.category)
-    self.navigationItem.rightBarButtonItem = UIBarButtonItem.titled(label).tap do |btn|
-      btn.target = self
-      btn.action = 'open_category'
-    end
-
-    subtitle = CategoryList.sharedCategories.key_to_title(self.category)
-    self.title = list_type == :hotentry ? "人気エントリー" : "新着エントリー"
+    self.title = if self.category
+                   CategoryList.sharedCategories.key_to_title(self.category)
+                 else
+                   list_type == :hotentry ? "人気エントリー" : "新着エントリー"
+                 end
 
     indexPath = tableView.indexPathForSelectedRow
     tableView.reloadData
@@ -136,38 +132,26 @@ class HotentryViewController < HBFav2::UITableViewController
     load_hotentry
   end
 
-  def open_category
-    controller = CategoryViewController.alloc.initWithStyle(UITableViewStyleGrouped)
-    controller.modalTransitionStyle = UIModalTransitionStyleFlipHorizontal
-    controller.current_category = self.category
-    controller.hotentry_controller = self
+  # def open_category
+  #   controller = CategoryViewController.alloc.initWithStyle(UITableViewStyleGrouped)
+  #   controller.modalTransitionStyle = UIModalTransitionStyleFlipHorizontal
+  #   controller.current_category = self.category
+  #   controller.hotentry_controller = self
 
-    self.presentViewController(
-      UINavigationController.alloc.initWithRootViewController(controller),
-      animated:true,
-      completion:nil
-    )
-  end
+  #   self.presentViewController(
+  #     UINavigationController.alloc.initWithRootViewController(controller),
+  #     animated:true,
+  #     completion:nil
+  #   )
+  # end
 
   def applicationWillEnterForeground
     load_hotentry
     self.view.reloadDataWithKeepingSelectedRowAnimated(true)
   end
 
-  # def performBackgroundFetchWithCompletion(completionHandler)
-  #   NSLog("###### Background Fetch : Update Hotentry ######")
-  #   load_hotentry do |res|
-  #     if res.ok?
-  #       completionHandler.call(UIBackgroundFetchResultNewData)
-  #     else
-  #       completionHandler.call(UIBackgroundFetchResultFailed)
-  #     end
-  #   end
-  # end
-
   def dealloc
     self.unreceive_application_switch_notification
-    NSLog("dealloc: " + self.class.name)
     super
   end
 end

--- a/app/controller/hotentry_view_controller.rb
+++ b/app/controller/hotentry_view_controller.rb
@@ -104,14 +104,6 @@ class HotentryViewController < HBFav2::UITableViewController
     super
   end
 
-  def viewWillDisappear(animated)
-    super
-    if @connection.present?
-      @connection.cancel
-      App.shared.networkActivityIndicatorVisible = false
-    end
-  end
-
   def tableView(tableView, numberOfRowsInSection:section)
     return @bookmarks.size
   end
@@ -154,6 +146,10 @@ class HotentryViewController < HBFav2::UITableViewController
   end
 
   def dealloc
+    if @connection.present?
+      @connection.cancel
+      App.shared.networkActivityIndicatorVisible = false
+    end    
     self.unreceive_application_switch_notification
     super
   end

--- a/app/controller/hotentry_view_controller.rb
+++ b/app/controller/hotentry_view_controller.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 class HotentryViewController < HBFav2::UITableViewController
-  attr_accessor :category, :list_type
+  attr_accessor :category, :list_type, :show_category_button
   include HBFav2::ApplicationSwitchNotification
 
   def viewDidLoad
@@ -82,6 +82,15 @@ class HotentryViewController < HBFav2::UITableViewController
     self.navigationController.setToolbarHidden(true, animated:animated)
     @indicator.center = [ view.center.x, view.center.y - 42]
 
+    ## category selector
+    if show_category_button
+      label =  CategoryList.sharedCategories.key_to_label(self.category)
+      self.navigationItem.rightBarButtonItem = UIBarButtonItem.titled(label).tap do |btn|
+        btn.target = self
+        btn.action = 'open_category'
+      end
+    end
+
     self.title = if self.category
                    CategoryList.sharedCategories.key_to_title(self.category)
                  else
@@ -132,18 +141,12 @@ class HotentryViewController < HBFav2::UITableViewController
     load_hotentry
   end
 
-  # def open_category
-  #   controller = CategoryViewController.alloc.initWithStyle(UITableViewStyleGrouped)
-  #   controller.modalTransitionStyle = UIModalTransitionStyleFlipHorizontal
-  #   controller.current_category = self.category
-  #   controller.hotentry_controller = self
-
-  #   self.presentViewController(
-  #     UINavigationController.alloc.initWithRootViewController(controller),
-  #     animated:true,
-  #     completion:nil
-  #   )
-  # end
+  def open_category
+    controller = CategoryViewController.alloc.initWithStyle(UITableViewStyleGrouped)
+    controller.list_type = list_type
+    controller.current_category = self.category
+    self.navigationController.pushViewController(controller, animated:true)
+  end
 
   def applicationWillEnterForeground
     load_hotentry

--- a/app/controller/left_view_controller.rb
+++ b/app/controller/left_view_controller.rb
@@ -46,10 +46,15 @@ class LeftViewController < UITableViewController
         :image      => UIImage.imageNamed('insignia_heart')
       },
       {
-        :title      => '新着エントリー',
-        :controller => HBFav2NavigationController.alloc.initWithRootViewController(controllers[:entrylist]),
+        :title      => 'カテゴリ',
+        :controller => HBFav2NavigationController.alloc.initWithRootViewController(controllers[:category]),
         :image      => UIImage.imageNamed('insignia_file')
-      },
+      },      
+#      {
+#        :title      => '新着エントリー',
+#        :controller => HBFav2NavigationController.alloc.initWithRootViewController(controllers[:entrylist]),
+#        :image      => UIImage.imageNamed('insignia_file')
+#      },
       {
         :title      => "アプリについて",
         :controller => HBFav2NavigationController.alloc.initWithRootViewController(controllers[:appInfo]),

--- a/app/controller/left_view_controller.rb
+++ b/app/controller/left_view_controller.rb
@@ -46,15 +46,10 @@ class LeftViewController < UITableViewController
         :image      => UIImage.imageNamed('insignia_heart')
       },
       {
-        :title      => 'カテゴリ',
-        :controller => HBFav2NavigationController.alloc.initWithRootViewController(controllers[:category]),
+        :title      => '新着エントリー',
+        :controller => HBFav2NavigationController.alloc.initWithRootViewController(controllers[:entrylist]),
         :image      => UIImage.imageNamed('insignia_file')
-      },      
-#      {
-#        :title      => '新着エントリー',
-#        :controller => HBFav2NavigationController.alloc.initWithRootViewController(controllers[:entrylist]),
-#        :image      => UIImage.imageNamed('insignia_file')
-#      },
+      },
       {
         :title      => "アプリについて",
         :controller => HBFav2NavigationController.alloc.initWithRootViewController(controllers[:appInfo]),

--- a/app/model/category_list.rb
+++ b/app/model/category_list.rb
@@ -32,6 +32,6 @@ class CategoryList
   end
 
   def to_datasource
-    @categories
+    @categories.select {|item| item[:key].present? }
   end
 end


### PR DESCRIPTION
人気エントリーをカテゴリ毎にみたいなーというときなんか今の UI だとカテゴリを切り替えてみていくのに若干手間がかかる感じがして、カテゴリ毎にみる行動をうまく誘発できてなかった。

ので変更。

ハンバーガーメニューから直接カテゴリ一覧が開けて、それぞれのカテゴリを pushView でいったりきたりするようにした。昔の公式アプリと同じ感じですね。

「人気エントリー」と「カテゴリ」で情報設計的には冗長なんだけど実際使って見るとこれでいいきがしている。

![2016-01-05 14 32 11](https://cloud.githubusercontent.com/assets/8991/12108288/5fd59c02-b3b9-11e5-85d9-a9c30c8d75f9.png)
![2016-01-05 14 32 14](https://cloud.githubusercontent.com/assets/8991/12108289/61782cf0-b3b9-11e5-94a3-344d85f6d192.png)
![2016-01-05 14 32 23](https://cloud.githubusercontent.com/assets/8991/12108291/645844b4-b3b9-11e5-815b-92cf7354fa31.png)

あとは新着をどうするか。新着も「新着」「カテゴリ」にしたほうがいいかもな