### PR TITLE
Expand tap region

### DIFF
--- a/app/cocoa/ui_view.rb
+++ b/app/cocoa/ui_view.rb
@@ -1,3 +1,16 @@
 class UIView
   include HBFav2::Rectangle
+
+  def resizeToFitWithSubviews
+    width = 0
+    height = 0
+
+    self.subviews.each do |v|
+      dw = v.frame.origin.x + v.frame.size.width
+      dh = v.frame.origin.y + v.frame.size.height
+      width  = dw if dw > width
+      height = dh if dh > height
+    end
+    self.frame = [self.frame.origin, [width, height]]
+  end
 end

--- a/app/controller/bookmark_view_controller.rb
+++ b/app/controller/bookmark_view_controller.rb
@@ -17,6 +17,8 @@ class BookmarkViewController < HBFav2::UIViewController
       v.starView.addGestureRecognizer(UITapGestureRecognizer.alloc.initWithTarget(self, action:'open_stars'))
       v.titleButton.addTarget(self, action:'open_webview', forControlEvents:UIControlEventTouchUpInside)
       v.titleButton.addGestureRecognizer(UILongPressGestureRecognizer.alloc.initWithTarget(self, action:'on_action'))
+      v.bookmarkItemView.addGestureRecognizer(UITapGestureRecognizer.alloc.initWithTarget(self, action:'open_webview'))
+      v.bookmarkItemView.addGestureRecognizer(UILongPressGestureRecognizer.alloc.initWithTarget(self, action:'on_action'))
       v.usersButton.addTarget(self, action:'open_bookmarks', forControlEvents:UIControlEventTouchUpInside)
       v.delegate = self
     end

--- a/app/view/bookmark_view.rb
+++ b/app/view/bookmark_view.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 module HBFav2
   class BookmarkView < UIView
-    attr_accessor :headerView, :usersButton, :starView, :titleButton
+    attr_accessor :headerView, :usersButton, :starView, :titleButton, :bookmarkItemView
 
     def self.sizeForThumbnail(image)
       if image.nil?
@@ -83,9 +83,12 @@ module HBFav2
           }
         end
 
-        @bodyView << @faviconView = UIImageView.new.tap {|v| v.frame = CGRectZero }
+        @bookmarkItemView = UIView.new.tap {|v| v.frame = CGRectZero}
+        @bodyView << @bookmarkItemView
 
-        @bodyView << @titleButton = UIButton.buttonWithType(UIButtonTypeCustom).tap do |btn|
+        @bookmarkItemView << @faviconView = UIImageView.new.tap {|v| v.frame = CGRectZero }
+
+        @bookmarkItemView << @titleButton = UIButton.buttonWithType(UIButtonTypeCustom).tap do |btn|
           btn.titleLabel.font = ApplicationConfig.sharedConfig.systemFontOfSize(17)
           btn.titleLabel.lineBreakMode = NSLineBreakByWordWrapping
           btn.titleLabel.numberOfLines = 0
@@ -96,11 +99,11 @@ module HBFav2
           btn.setTitle("", forState:UIControlStateNormal)
         end
 
-        @bodyView << @thumbnailImageView = UIImageView.new.tap do |v|
+        @bookmarkItemView << @thumbnailImageView = UIImageView.new.tap do |v|
           v.frame = CGRectZero
         end
 
-        @bodyView << @descriptionLabel = UILabel.new.tap do |v|
+        @bookmarkItemView << @descriptionLabel = UILabel.new.tap do |v|
           v.frame = CGRectZero
           v.numberOfLines = 0
           v.font = ApplicationConfig.sharedConfig.systemFontOfSize(13)
@@ -108,7 +111,7 @@ module HBFav2
           v.lineBreakMode = NSLineBreakByWordWrapping|NSLineBreakByTruncatingTail
         end
 
-        @bodyView << @urlLabel = UILabel.new.tap do |v|
+        @bookmarkItemView << @urlLabel = UILabel.new.tap do |v|
           v.frame = CGRectZero
           v.numberOfLines = 0
           v.font = ApplicationConfig.sharedConfig.systemFontOfSize(13)
@@ -117,13 +120,13 @@ module HBFav2
           v.text = ""
         end
 
-        @bodyView << @dateLabel = UILabel.new.tap do |v|
+        @bookmarkItemView << @dateLabel = UILabel.new.tap do |v|
           v.frame = CGRectZero
           v.font = UIFont.systemFontOfSize(13)
           v.textColor = '#999'.uicolor
         end
 
-        @bodyView << @starView = HBFav2::HatenaStarView.new
+        @bookmarkItemView << @starView = HBFav2::HatenaStarView.new
 
         @bodyView << @usersButton = UIButton.buttonWithType(UIButtonTypeRoundedRect).tap do |button|
           button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft
@@ -249,6 +252,8 @@ module HBFav2
       end
 
       y = @commentLabel.text.present? ? @commentLabel.bottom : @border.bottom + 5
+      @bookmarkItemView.frame = [[0, y], @bookmarkItemView.frame.size]
+      y = 0
 
       # favicon
       @faviconView.frame = [[10, y + 6], [16, 16]]
@@ -309,8 +314,11 @@ module HBFav2
       origin = @dateLabel.frame.origin
       @starView.origin = [origin.x + @dateLabel.frame.size.width + 3, origin.y + 3.5]
 
+      # calculate bookmarkItemView size
+      @bookmarkItemView.resizeToFitWithSubviews
+
       # button
-      @usersButton.frame = [[10, @dateLabel.bottom + 10], [self.frame.size.width - 20, 40]]
+      @usersButton.frame = [[10, @bookmarkItemView.bottom + 10], [self.frame.size.width - 20, 40]]
 
       if UIDevice.currentDevice.ios7_or_later?
         @usersButtonBorderTop.frame    = [[15, @usersButton.top], [self.right - 30, 1]]


### PR DESCRIPTION
WebView に遷移する際にタイトル部分しかタップに反応しなかったのを変更してみました。

### Before

![before](http://cl.ly/303Q0n3w2d07/before.png)

### After

![after](http://cl.ly/0H2E133r272O/after.png)

iPhone 6 を片手で操作しているとタイトル部分まで手がぎりぎり届かなかったりするので、
使いやすくなるかと思います。

コメント部分は、今まで通りにしてあります。
(コメント部分を含めると、コメントの URL にジャンプできなかったので。)