### PR TITLE
set Japanese as default environment

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,8 @@ Bundler.require :default
 require 'sugarcube-attributedstring'
 require 'bubble-wrap/reactor'
 
+ENV['args'] ||= "-AppleLanguages '(ja)'"
+
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.
   app.name = 'HBFav'


### PR DESCRIPTION
`rake`でシミュレータを起動する際に、デフォルトで日本語環境が適用されるようにしてみました。
中華フォントの代わりに、ちゃんとしたもので表示されるようになります。

詳細は、 http://qiita.com/watson1978/items/399b62445b5494fdf512