### PR TITLE
Migrate from `Readability' to `Mercury' service

### DIFF
--- a/app/util/readability.rb
+++ b/app/util/readability.rb
@@ -2,10 +2,10 @@
 module Readability
   class Parser
     attr_accessor :api_token
-    API = "https://www.readability.com/api/content/v1/parser"
+    API = "https://mercury.postlight.com/parser"
 
     def parse_url(url, &cb)
-      query = BW::HTTP.get(API, {payload: {url: url, token: api_token}}) do |response|
+      query = BW::HTTP.get(API, {payload: {url: url}, headers: {:"x-api-key" => api_token}}) do |response|
         if response.ok?
           data = BW::JSON.parse(response.body.to_str)
           cb.call(response, html(data)) if cb


### PR DESCRIPTION
Readability がサービスを終了していて HBFav で利用できなくなっています。

https://www.readability.com で mercury (https://mercury.postlight.com/web-parser/) に移行するのが簡単と書かれていたので最低限の変更を加えて、Mercury を使うようにしました。

1. この PR をマージ
2. https://mercury.postlight.com/web-parser/ にサインアップして API KEY を取得
3. `config/environment.yaml` の

```
readability:
  api_token: XXXXXXX
```

を取得したAPI KEY に書き換えると動くはずです。